### PR TITLE
Escape source blocks only when pygments is not available

### DIFF
--- a/orgpython/block.py
+++ b/orgpython/block.py
@@ -261,6 +261,10 @@ class Src(Block):
         self.language = language
         self.label = "<pre class=\"src src-{0}\">\n{1}\n</pre>"
 
+    def init(self):
+        if pygments is not None:
+            self.escape = False
+
     @classmethod
     def new(cls, text):
         match = R.begin_src.match(text)


### PR DESCRIPTION
Escaping is defined by a general call, and defaults to True as it
should. However when using pygments for syntax highlighting using the
HTMLFormatter the escaping happens twice.

This makes symbols like ">" to be escaped twice. Leaving bad code blocks on
the HTML output.

Minimal example to reproduce ill behavior:

``` 
from orgpython import org_to_html

text = """
this > that
#+begin_src python
cat file > /dev/null
#+end_src

"""
org_to_html(text, toc=False)
```